### PR TITLE
feat: parse config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@
 *.exe
 *.out
 *.app
+
+webserv

--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,13 @@ BPurple			= '\033[1;35m'    # Purple
 BCyan			= '\033[1;36m'    # Cyan
 
 
-CC				= c++  
+CC				= c++
 CFLAGS			= -g -Wall -Wextra -Werror -std=c++98 -MMD -MP -pedantic
 RM 				= rm -rf
 
-SRC				= main.cpp
+SRC				= main.cpp FileParser.cpp Server.cpp ServerLocation.cpp Utils.cpp
 
-INCPATH  		= -I./srcs -I./srcs/req -I./srcs/resp -I./srcs/serv 
+INCPATH  		= -I./srcs -I./srcs/req -I./srcs/resp -I./srcs/serv
 
 OBJDIR			= objects
 OBJ				= $(SRC:%.cpp=$(OBJDIR)/%.o)
@@ -35,9 +35,9 @@ clean:
 	@$(RM) $(OBJ_DIR)
 
 fclean: clean
-	@$(RM) $(NAME) 
+	@$(RM) $(NAME)
 
-re: 
+re:
 	@fclean all
 
 run:
@@ -50,6 +50,8 @@ run:
 	@echo "\n\033[1;35m🌐 Exec WebServ\033[0m"
 	@./$(NAME) default.conf
 
+valgrind: all
+	valgrind --tool=memcheck --leak-check=full --track-origins=yes --show-leak-kinds=all ./webserv
 
 $(OBJDIR):
 	mkdir -p objects

--- a/default.conf
+++ b/default.conf
@@ -1,149 +1,162 @@
 server {
-	listen 127.0.0.1:3490;
-	root root_html;
-	server_name www.localhost localhost;
-    
-	index index.html index.htm;
-	error_page 408 404 /40x.html custom_404.html custom_405.html;
-	error_page 500 502 503 504 /50x.html;
+  listen 127.0.0.1:3490
+  root root_html
+  server_name www.localhost localhost
 
-	client_max_body_size 100;
+  index index.html index.htm
+  error_page 408 404 /40x.html
+  error_page 500 502 503 504 /50x.html
 
-	accepted_request_methods GET POST;
-	
-	cgi .sh /bin/bash;
-	cgi .php /bin/php;
-	cgi .bla ubuntu_cgi_tester;
-	cgi .php php-cgi;
-	cgi .py python3;
-	
-	timeout 50000;
+  client_body_size 100
 
-	#1st test
-	location
-	{
-		uri /file_upload;
-		root root_html/file_upload;
-		autoindex on;
-		accepted_request_methods POST GET DELETE;
-		client_max_body_size 104857601;
-	}
- 
-	#2nd test
-	location
-	{
-		uri /file_delete;
-		autoindex on;
-		limit_except GET DELETE;
-		root root_html/file_delete;
-	}
+  allowed_methods GET POST
 
-	#3rd test
-	location
-	{
-		uri /uri_alias;
-		root root_html/substitution;
-	}
+  cgi .py
 
-	#4rd test
-	location  
-	{
-		uri /redirect_301;
-		return 301 https://http.cat/301;
-	}
-	location  
-	{
-		uri /redirect_302;
-		return 302 https://http.cat/302;
-	}
 
-	#5rd test
-	location
-	{
-		uri /autoindex-demo;
-	}
+  #1st test
+  location / {
+    index /file_upload
+    root root_html/file_upload
+    autoindex on
+    allowed_methods POST GET DELETE
+    client_body_size 104857601
+  };
 
-	#6rd test
-	location
-	{
-		uri /autoindex-off;
-		autoindex off;
-	}
-}
+  #2nd test
+  location /teste {
+    index /file_delete
+    autoindex on
+    allowed_methods GET DELETE
+    root root_html/file_delete
+  };
+
+  #3rd test
+  location /123 {
+    index /index_alias
+    root root_html/substitution
+  };
+
+  #4rd test
+  location /redirect {
+    index /redirect_301
+    return 301 https://http.cat/301
+  };
+
+  location /teste1 {
+    index /redirect_302
+    return 302 https://http.cat/302
+  };
+
+  #5rd test
+  location /autoindex-off {
+    index /autoindex-demo
+  };
+
+  #6rd test
+  location /autoindex-on {
+    index /autoindex-off
+    autoindex off
+  };
+};
 
 
 #server in another port
 server {
-	listen 127.0.0.1:3491;
-	server_name www.localhost1 localhost1;
-	root root_html;
-	index index2.html;
-	error_page 404 custom_404.html;
-	error_page 405 custom_405.html;
-	timeout 50000;
-	client_max_body_size 100;
+  listen 127.0.0.1:3491
+  server_name www.localhost1 localhost1
+  root root_html
+  index index2.html
+  error_page 404 custom_404.html
+  error_page 405 custom_405.html
+  client_body_size 100
 
-	location 
-	{
-		limit_except GET;
-	}
-}
+  location /gets {
+    allowed_methods GET
+  };
+};
 
 
-
-
-
-
-# server will block server_name 
-server
-{
-	listen 3490;
-	server_name anything;
-	root root_html/block_server;
-}
+# server will block server_name
+server {
+  listen localhost:3490
+  server_name anything
+  root root_html/block_server
+};
 
 
 
 
 #Existent server_name without root: forbid access.
-server
-{
-	listen 3490;
-	server_name rootless;
-}
+server {
+  listen localhost:3490
+  server_name rootless
+};
 
 
 #More redirect
-server
-{
-	listen 3493 3494
-	redirect http://localhost:3490/
-}
+server {
+  listen teste:3494
+  return 301 http://localhost:3490/
+};
 
 
 
 
 #First server of localhost:3490 is above, so this is ignored.
-server
-{
-	listen 3490;
-	root bad_folder;
-}
+server {
+  listen localhost:3490
+  root bad_folder
+};
+
+server {
+  listen localhost:3491
+  root html-3491
+  index index.html index.htm
+  allowed_methods GET
+};
 
 
+#  No "location", "root", nor "redirect", so it is forbidden 403.
+server {
+  listen localhost:3492
+};
 
+server {
+  listen localhost:80
+  server_name webserv
+  root ./test
+  error_page 500 502 503 504  /test/test.html
+  client_body_size 123
+  allowed_methods GET POST
+  autoindex on
+  return 301 http://google.com
+  cgi .py
+  index test.txt teste2.txt
 
-server
-{
-	listen 3491;
-	root html-3491;
-	index index.html index.htm;
-	accepted_request_methods GET;
-}
+  location / {
+    autoindex off
+  };
 
+  location /test/2 {
+    return 301 /
+  };
 
-#	No "location", "root", nor "redirect", so it is forbidden 403.
-server
-{
-	listen	3492;
-}
+};
+
+server {
+  listen localhost:3000
+  server_name webserv2
+  root ./test2
+  error_page 500 502 503 504  /test/test.html
+  client_body_size 12345
+
+  location / {
+    autoindex on
+  };
+
+  location /test/2 {
+    return 301 /
+  };
+};
+

--- a/srcs/FileParser.cpp
+++ b/srcs/FileParser.cpp
@@ -1,0 +1,42 @@
+#include <FileParser.hpp>
+
+FileParser::FileParser(void) {}
+
+FileParser::FileParser(FileParser const &file_parser) {
+	(void)file_parser;
+}
+
+FileParser &FileParser::operator=(FileParser const &file_parser) {
+	(void)file_parser;
+	return *this;
+}
+
+FileParser::~FileParser(void) {}
+
+void FileParser::parse(void) {
+	std::ifstream	fs;
+	std::string		line;
+	std::vector<Server> servers;
+
+	fs.open("./default.conf", std::ifstream::in);
+
+	if(!fs.is_open())
+		throw std::exception();
+
+	while (!fs.eof())
+	{
+		std::getline(fs, line);
+		_parse_server(fs, line);
+	}
+	fs.close();
+}
+
+void FileParser::_parse_server(std::ifstream &fs, std::string line) {
+		Server server;
+
+		if (line == "server {") {
+			server.parse_server_attributes(fs, line);
+			std::cout << server << std::endl;
+		}
+
+}

--- a/srcs/FileParser.hpp
+++ b/srcs/FileParser.hpp
@@ -1,0 +1,23 @@
+#ifndef FILEPARSER_HPP
+#define FILEPARSER_HPP
+
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <Server.hpp>
+
+class FileParser {
+	private:
+		std::vector<Server>	_servers;
+		void	_parse_server(std::ifstream &fs, std::string line);
+
+	public:
+		FileParser(void);
+		FileParser(FileParser const &file_parser);
+		FileParser& operator=(FileParser const &file_parser);
+		~FileParser(void);
+
+		void parse(void);
+};
+
+#endif

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1,0 +1,170 @@
+#include <Server.hpp>
+
+
+Server::Server(void) : _autoindex(false) {}
+
+Server::Server(Server const &server) {
+	(void)server;
+}
+
+Server &Server::operator=(Server const &server) {
+	(void)server;
+	return *this;
+}
+
+Server::~Server(void) {}
+
+void	Server::parse_server_attributes(std::ifstream &fs, std::string line) {
+	std::vector<std::string> line_tokens;
+
+	while (!fs.eof())
+	{
+		std::getline(fs, line);
+		line_tokens = Utils::string_split(line, ' ');
+		if (line_tokens.empty())
+			continue;
+		if (line_tokens.size() >= 3 && line_tokens[0] == "location" && line_tokens[2] == "{")
+			this->_parse_location_attributes(fs, line, line_tokens[1]);
+		else if (line_tokens.size() >= 1 && line_tokens[0] == "};")
+			return ;
+		else
+			this->_set_server_attributes(line_tokens);
+	}
+}
+
+std::vector<std::string> Server::server_names(void) const { return _server_names; }
+std::string Server::host(void) const { return _host; }
+int Server::port(void) const { return _port; }
+std::map<int, std::string> Server::erros_pages(void) const { return _erros_pages; }
+std::vector<std::string> Server::http_methods(void) const { return _http_methods; }
+std::pair<int, std::string> Server::http_redirect(void) const { return _http_redirect; }
+std::string Server::root(void) const { return _root; }
+int Server::body_size_limit(void) const { return _body_size_limit; }
+bool Server::autoindex(void) const { return _autoindex; }
+std::vector<std::string> Server::index(void) const { return _index; }
+std::map<std::string, ServerLocation> Server::locations(void) const { return _locations; }
+ServerLocation Server::location(std::string path) const { return _locations.at(path); }
+std::string Server::cgi_extension(void) const { return _cgi_extension; }
+
+void	Server::_parse_location_attributes(std::ifstream &fs, std::string line, std::string path) {
+	ServerLocation location(*this);
+	location.parse_location_attributes(fs, line);
+	_locations[path] = location;
+}
+
+void	Server::_set_server_attributes(std::vector<std::string> line_tokens) {
+	if (line_tokens[0] == "listen")
+		_set_listen_attribute(line_tokens);
+	else if (line_tokens[0] == "server_name")
+		_set_server_name_attribute(line_tokens);
+	else if (line_tokens[0] == "root")
+		_set_root_attribute(line_tokens);
+	else if (line_tokens[0] == "error_page")
+		_set_error_page_attribute(line_tokens);
+	else if (line_tokens[0] == "client_body_size")
+		_set_client_body_size_attribute(line_tokens);
+	else if (line_tokens[0] == "cgi")
+		_set_cgi_attribute(line_tokens);
+	else if (line_tokens[0] == "allowed_methods")
+		_set_http_methods_attribute(line_tokens);
+	else if (line_tokens[0] == "autoindex")
+		_set_autoindex_attribute(line_tokens);
+	else if (line_tokens[0] == "return")
+		_set_http_redirect_attribute(line_tokens);
+	else if (line_tokens[0] == "root")
+		_set_root_attribute(line_tokens);
+	else if (line_tokens[0] == "index")
+		_set_index_attribute(line_tokens);
+}
+
+void	Server::_set_listen_attribute(std::vector<std::string> line_tokens) {
+	std::vector<std::string> listen_atributes = Utils::string_split(line_tokens[1], ':');
+
+	this->_host = listen_atributes[0];
+	this->_port = std::atoi(listen_atributes[1].c_str());
+}
+
+void	Server::_set_server_name_attribute(std::vector<std::string> line_tokens) {
+	for(long unsigned int j = 1; j < line_tokens.size(); j++)
+		this->_server_names.push_back(line_tokens[j]);
+}
+
+void	Server::_set_error_page_attribute(std::vector<std::string> line_tokens) {
+	for(long unsigned int j = 1; j < line_tokens.size() - 1; j++)
+		this->_erros_pages[std::atoi(line_tokens[j].c_str())] = line_tokens[line_tokens.size() - 1];
+
+}
+
+void	Server::_set_client_body_size_attribute(std::vector<std::string> line_tokens) {
+	this->_body_size_limit = std::atoi(line_tokens[1].c_str());
+}
+
+void	Server::_set_cgi_attribute(std::vector<std::string> line_tokens) {
+	this->_cgi_extension = line_tokens[1];
+}
+
+void	Server::_set_http_methods_attribute(std::vector<std::string> line_tokens) {
+	for(long unsigned int j = 1; j < line_tokens.size(); j++)
+		this->_http_methods.push_back(line_tokens[j]);
+}
+
+void	Server::_set_http_redirect_attribute(std::vector<std::string> line_tokens) {
+	this->_http_redirect = std::make_pair(std::atoi(line_tokens[1].c_str()), line_tokens[2]);
+}
+
+void	Server::_set_root_attribute(std::vector<std::string> line_tokens) {
+	this->_root = line_tokens[1];
+}
+
+void	Server::_set_autoindex_attribute(std::vector<std::string> line_tokens) {
+	this->_autoindex = line_tokens[1] == "on";
+}
+
+void	Server::_set_index_attribute(std::vector<std::string> line_tokens) {
+	for(long unsigned int j = 1; j < line_tokens.size(); j++)
+		this->_index.push_back(line_tokens[j]);
+}
+
+std::ostream &operator<<(std::ostream &out, const Server &server)
+{
+	out << "Server Names: " << std::endl;
+	std::vector<std::string> server_names = server.server_names();
+	for(std::vector<std::string>::const_iterator  it = server_names.begin(); it != server_names.end(); it++)
+		out << " " << *it << std::endl;
+
+	out << "Host: " << server.host() << std::endl;
+	out << "Port: " << server.port() << std::endl;
+
+
+	out << "Client max body size: " << server.body_size_limit() << std::endl;
+
+	out << "Cgi extension: " << server.cgi_extension() << std::endl;
+
+	out << "Root: " << server.root() << std::endl;
+
+	out << "Autoindex: " << server.autoindex() << std::endl;
+
+	out << "Indexes: " << std::endl;
+	std::vector<std::string> index = server.index();
+	for(std::vector<std::string>::const_iterator  it = index.begin(); it != index.end(); it++)
+		out << " " << *it << std::endl;
+
+	out << "Http allowed methods: " << std::endl;
+	std::vector<std::string> http_methods = server.http_methods();
+	for(std::vector<std::string>::const_iterator  it = http_methods.begin(); it != http_methods.end(); it++)
+		out << " " << *it << std::endl;
+
+	out << "Errors: " << std::endl;
+	std::map<int, std::string> erros_pages = server.erros_pages();
+	for (std::map<int, std::string>::const_iterator  it = erros_pages.begin(); it != erros_pages.end(); it++)
+			out << " " << "status-" << it->first << " file-" << it->second << std::endl;
+
+	out << "Http redirect: status-" << server.http_redirect().first << " destination-" << server.http_redirect().second << std::endl;
+
+	out << "Locations: " << std::endl;
+	std::map<std::string, ServerLocation> locations = server.locations();
+	for (std::map<std::string, ServerLocation>::const_iterator  it = locations.begin(); it != locations.end(); it++)
+		out << " " << it->first << ":" << std::endl << it->second << std::endl;
+
+	return (out);
+}

--- a/srcs/Server.hpp
+++ b/srcs/Server.hpp
@@ -1,0 +1,67 @@
+#ifndef SERVER_HPP
+#define SERVER_HPP
+
+#include <stdlib.h>
+#include <iostream>
+#include <vector>
+#include <fstream>
+#include <map>
+#include <ServerLocation.hpp>
+#include <Utils.hpp>
+
+class ServerLocation;
+
+class Server {
+	private:
+		std::vector<std::string>							_server_names;
+		std::string														_host;
+		int																		_port;
+		std::map<int, std::string>						_erros_pages;
+		std::vector<std::string>							_http_methods;
+		std::pair<int, std::string>						_http_redirect;
+		std::string														_root;
+		int																		_body_size_limit;
+		bool																	_autoindex;
+		std::vector<std::string>							_index;
+		std::map<std::string, ServerLocation>	_locations;
+		std::string														_cgi_extension;
+
+		void	_parse_location_attributes(std::ifstream &fs, std::string line, std::string path);
+		void	_set_server_attributes(std::vector<std::string> line_tokens);
+		void	_set_listen_attribute(std::vector<std::string> line_tokens);
+		void	_set_server_name_attribute(std::vector<std::string> line_tokens);
+		void	_set_error_page_attribute(std::vector<std::string> line_tokens);
+		void	_set_client_body_size_attribute(std::vector<std::string> line_tokens);
+		void	_set_cgi_attribute(std::vector<std::string> line_tokens);
+		void	_set_http_methods_attribute(std::vector<std::string> line_tokens);
+		void	_set_http_redirect_attribute(std::vector<std::string> line_tokens);
+		void	_set_root_attribute(std::vector<std::string> line_tokens);
+		void	_set_autoindex_attribute(std::vector<std::string> line_tokens);
+		void	_set_index_attribute(std::vector<std::string> line_tokens);
+
+	public:
+		Server(void);
+		Server(Server const &server);
+		Server& operator=(Server const &server);
+		~Server(void);
+
+		void	parse_server_attributes(std::ifstream &fs, std::string line);
+
+		std::vector<std::string>							server_names(void) const;
+		std::string														host(void) const;
+		int																		port(void) const;
+		std::map<int, std::string>						erros_pages(void) const;
+		std::vector<std::string>							http_methods(void) const;
+		std::pair<int, std::string>						http_redirect(void) const;
+		std::string														root(void) const;
+		int																		body_size_limit(void) const;
+		bool																	autoindex(void) const;
+		std::vector<std::string>							index(void) const;
+		std::map<std::string, ServerLocation>	locations(void) const;
+		std::string														cgi_extension(void) const;
+		ServerLocation												location(std::string path) const;
+};
+
+std::ostream &operator<<(std::ostream &out, const Server &server);
+
+#endif

--- a/srcs/ServerLocation.cpp
+++ b/srcs/ServerLocation.cpp
@@ -1,0 +1,154 @@
+#include <ServerLocation.hpp>
+
+
+ServerLocation::ServerLocation(void) : _autoindex(false) {}
+
+ServerLocation::ServerLocation(Server const &server) {
+	_http_methods = server.http_methods();
+	_http_redirect = server.http_redirect();
+	_root = server.root();
+	_autoindex = server.autoindex();
+	_index = server.index();
+	_cgi_extension = server.cgi_extension();
+	_erros_pages = server.erros_pages();
+	_body_size_limit = server.body_size_limit();
+}
+
+ServerLocation::ServerLocation(ServerLocation const &server_location) {
+	_http_methods = server_location.http_methods();
+	_http_redirect = server_location.http_redirect();
+	_root = server_location.root();
+	_autoindex = server_location.autoindex();
+	_index = server_location.index();
+	_cgi_extension = server_location.cgi_extension();
+	_erros_pages = server_location.erros_pages();
+	_body_size_limit = server_location.body_size_limit();
+}
+
+ServerLocation &ServerLocation::operator=(ServerLocation const &server_location) {
+	if (this != &server_location) {
+		_http_methods = server_location.http_methods();
+		_http_redirect = server_location.http_redirect();
+		_root = server_location.root();
+		_autoindex = server_location.autoindex();
+		_index = server_location.index();
+		_cgi_extension = server_location.cgi_extension();
+		_erros_pages = server_location.erros_pages();
+		_body_size_limit = server_location.body_size_limit();
+	}
+
+	return *this;
+}
+
+ServerLocation::~ServerLocation(void) {}
+
+void	ServerLocation::parse_location_attributes(std::ifstream &fs, std::string line) {
+	std::vector<std::string> line_tokens;
+
+	while (!fs.eof())
+	{
+		std::getline(fs, line);
+		line_tokens = Utils::string_split(line, ' ');
+		if (line_tokens.size() >= 1 && line_tokens[0] == "};")
+			return ;
+		else
+			this->_set_location_attributes(line_tokens);
+	}
+}
+
+std::map<int, std::string> ServerLocation::erros_pages(void) const { return _erros_pages; }
+std::vector<std::string> ServerLocation::http_methods(void) const { return _http_methods; }
+std::pair<int, std::string> ServerLocation::http_redirect(void) const { return _http_redirect; }
+std::string ServerLocation::root(void) const { return _root; }
+int ServerLocation::body_size_limit(void) const { return _body_size_limit; }
+bool ServerLocation::autoindex(void) const { return _autoindex; }
+std::vector<std::string> ServerLocation::index(void) const { return _index; }
+std::string ServerLocation::cgi_extension(void) const { return _cgi_extension; }
+
+void	ServerLocation::_set_location_attributes(std::vector<std::string> line_tokens) {
+	if (line_tokens[0] == "root")
+		_set_root_attribute(line_tokens);
+	else if (line_tokens[0] == "error_page")
+		_set_error_page_attribute(line_tokens);
+	else if (line_tokens[0] == "client_body_size")
+		_set_client_body_size_attribute(line_tokens);
+	else if (line_tokens[0] == "cgi")
+		_set_cgi_attribute(line_tokens);
+	else if (line_tokens[0] == "allowed_methods")
+		_set_http_methods_attribute(line_tokens);
+	else if (line_tokens[0] == "autoindex")
+		_set_autoindex_attribute(line_tokens);
+	else if (line_tokens[0] == "return")
+		_set_http_redirect_attribute(line_tokens);
+	else if (line_tokens[0] == "root")
+		_set_root_attribute(line_tokens);
+	else if (line_tokens[0] == "index")
+		_set_index_attribute(line_tokens);
+}
+
+
+void	ServerLocation::_set_error_page_attribute(std::vector<std::string> line_tokens) {
+	for(long unsigned int j = 1; j < line_tokens.size() - 1; j++)
+		this->_erros_pages[std::atoi(line_tokens[j].c_str())] = line_tokens[line_tokens.size() - 1];
+
+}
+
+void	ServerLocation::_set_client_body_size_attribute(std::vector<std::string> line_tokens) {
+	this->_body_size_limit = std::atoi(line_tokens[1].c_str());
+}
+
+void	ServerLocation::_set_cgi_attribute(std::vector<std::string> line_tokens) {
+	this->_cgi_extension = line_tokens[1];
+}
+
+void	ServerLocation::_set_http_methods_attribute(std::vector<std::string> line_tokens) {
+	for(long unsigned int j = 1; j < line_tokens.size(); j++)
+		this->_http_methods.push_back(line_tokens[j]);
+}
+
+void	ServerLocation::_set_http_redirect_attribute(std::vector<std::string> line_tokens) {
+	this->_http_redirect = std::make_pair(std::atoi(line_tokens[1].c_str()), line_tokens[2]);
+}
+
+void	ServerLocation::_set_root_attribute(std::vector<std::string> line_tokens) {
+	this->_root = line_tokens[1];
+}
+
+void	ServerLocation::_set_autoindex_attribute(std::vector<std::string> line_tokens) {
+	this->_autoindex = line_tokens[1] == "on";
+}
+
+void	ServerLocation::_set_index_attribute(std::vector<std::string> line_tokens) {
+	for(long unsigned int j = 1; j < line_tokens.size(); j++)
+		this->_index.push_back(line_tokens[j]);
+}
+
+std::ostream &operator<<(std::ostream &out, ServerLocation const &server_location)
+{
+	out << "  Client max body size: " << server_location.body_size_limit() << std::endl;
+
+	out << "  Cgi extension: " << server_location.cgi_extension() << std::endl;
+
+	out << "  Root: " << server_location.root() << std::endl;
+
+	out << "  Autoindex: " << server_location.autoindex() << std::endl;
+
+	out << "  Indexes: " << std::endl;
+	std::vector<std::string> index = server_location.index();
+	for(std::vector<std::string>::const_iterator  it = index.begin(); it != index.end(); it++)
+		out << "   " << *it << std::endl;
+
+	out << "  Http allowed methods: " << std::endl;
+	std::vector<std::string> http_methods = server_location.http_methods();
+	for(std::vector<std::string>::const_iterator  it = http_methods.begin(); it != http_methods.end(); it++)
+		out << "   " << *it << std::endl;
+
+	out << "  Errors: " << std::endl;
+	std::map<int, std::string> erros_pages = server_location.erros_pages();
+	for (std::map<int, std::string>::const_iterator  it = erros_pages.begin(); it != erros_pages.end(); it++)
+			out << "   " << "status-" << it->first << " file-" << it->second << std::endl;
+
+	out << "  Http redirect: status-" << server_location.http_redirect().first << " destination-" << server_location.http_redirect().second << std::endl;
+
+	return (out);
+}

--- a/srcs/ServerLocation.hpp
+++ b/srcs/ServerLocation.hpp
@@ -1,0 +1,58 @@
+#ifndef SERVERLOCATION_HPP
+#define SERVERLOCATION_HPP
+
+#include <stdlib.h>
+#include <iostream>
+#include <vector>
+#include <map>
+#include <fstream>
+#include <Utils.hpp>
+#include <Server.hpp>
+
+class Server;
+
+class ServerLocation {
+	private:
+		std::vector<std::string>		_http_methods;
+		std::pair<int, std::string>	_http_redirect;
+		std::string									_root;
+		bool												_autoindex;
+		std::vector<std::string>		_index;
+		std::string									_cgi_extension;
+		std::map<int, std::string>	_erros_pages;
+		int													_body_size_limit;
+
+		void	_set_location_attributes(std::vector<std::string>);
+		void	_set_error_page_attribute(std::vector<std::string> line_tokens);
+		void	_set_client_body_size_attribute(std::vector<std::string> line_tokens);
+		void	_set_cgi_attribute(std::vector<std::string> line_tokens);
+		void	_set_http_methods_attribute(std::vector<std::string> line_tokens);
+		void	_set_http_redirect_attribute(std::vector<std::string> line_tokens);
+		void	_set_root_attribute(std::vector<std::string> line_tokens);
+		void	_set_autoindex_attribute(std::vector<std::string> line_tokens);
+		void	_set_index_attribute(std::vector<std::string> line_tokens);
+
+
+	public:
+		ServerLocation(void);
+		ServerLocation(Server const &server);
+		ServerLocation(ServerLocation const &server_location);
+		ServerLocation& operator=(ServerLocation const &server_location);
+		~ServerLocation(void);
+
+		void parse_location_attributes(std::ifstream &fs, std::string line);
+
+		std::map<int, std::string>						erros_pages(void) const;
+		std::vector<std::string>							http_methods(void) const;
+		std::pair<int, std::string>						http_redirect(void) const;
+		std::string														root(void) const;
+		int																		body_size_limit(void) const;
+		bool																	autoindex(void) const;
+		std::vector<std::string>							index(void) const;
+		std::string														cgi_extension(void) const;
+};
+
+std::ostream &operator<<(std::ostream &out, ServerLocation const &server_location);
+
+
+#endif

--- a/srcs/Utils.cpp
+++ b/srcs/Utils.cpp
@@ -1,0 +1,31 @@
+#include <Utils.hpp>
+
+namespace Utils {
+	std::vector<std::string> string_split(const std::string str, char seperator)
+	{
+			std::vector<std::string> tokens;
+
+			int len = str.length(), i = -1;
+			int start_index = 0, size;
+
+			while (++i < len)
+			{
+				while (str[i] == seperator)
+				{
+					i++;
+					continue ;
+				}
+
+				start_index = i;
+
+				while (i <= len && str[i] != seperator)
+					i++;
+
+				size = i - start_index;
+
+				tokens.push_back(str.substr(start_index, size));
+			}
+
+			return tokens;
+	}
+}

--- a/srcs/Utils.hpp
+++ b/srcs/Utils.hpp
@@ -1,0 +1,12 @@
+#ifndef UTILS_HPP
+#define UTILS_HPP
+
+#include <iostream>
+#include <vector>
+
+
+namespace Utils {
+	std::vector<std::string> string_split(const std::string str, char seperator);
+}
+
+#endif

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -1,0 +1,13 @@
+#include <Server.hpp>
+#include <FileParser.hpp>
+
+int	main(int argc, char **argv)
+{
+	(void)argc;
+	(void)argv;
+
+	FileParser fileParser;
+	fileParser.parse();
+
+	return (0);
+}


### PR DESCRIPTION
## Esse PR tem como objetivo realizar o parse do arquivo de configuração e transformá-lo em objetos que poderão se lidos na aplicação.


### Descrição
Eu basicamente criei a classe **FileParser** que é responsável por realizar o parse do arquivo de configuração e retornará uma array de **Servers** (cada **server** presente no arquivo de configuração será um server dentro desse array). 

A classe **Server** contém todas as configurações necessárias para iniciar o server, possibilitando já iniciar os nossos servers em nosso projeto. 

### Como testar
Basta rodar:
```make && ./webserv```


### Observações
- Essa feature não está 100% completa, faltam pequenos ajustes para tornar nossa aplicação mais resiliente (como validação dos inputs e sanitização dos dados).
- Em relação a estrutura dos arquivos, eu deixei na raiz por enquanto. A medida que o projeto for crescendo sem dúvida vamos movê-los para as pastas com nomenclaturas mais adequadas. 
- O que eu foquei foi em já entregar algo funcional para já irmos prosseguirmos no projeto, e esses pequenos ajustes podemos fazer em paralelo ou deixar para o final.
- Por enquanto o programa logga no stdout todos os servers que foram parseados, deixando visível os dados que parseamos.
- Criei um script que roda o projeto já com o valgrind, é interessante sempre rodarmos o comando ```make valgrind``` para garantirmos a ausência de leaks