### PR TITLE
Adds CGI support to the webserver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ CC				= c++
 CFLAGS			= -g -Wall -Wextra -Werror -std=c++98 -MMD -MP -pedantic
 RM 				= rm -rf
 
-SRC				= main.cpp FileParser.cpp Http.cpp Request.cpp Response.cpp \
+SRC				= main.cpp CgiHandler.cpp FileParser.cpp Http.cpp Request.cpp Response.cpp \
 						Server.cpp ServerLocation.cpp Utils.cpp WebServ.cpp
 
 INCPATH  		= -I./srcs -I./srcs/req -I./srcs/resp -I./srcs/serv
@@ -76,7 +76,7 @@ poetry_uninstall:
 # **************************************************************************** #
 # *----------------------------Virtual Environment---------------------------* #
 # **************************************************************************** #
-VENV_DIR = ./.venv # TODO instead of relative path, set folder equal to makefile location
+VENV_DIR = ./.venv
 venv_install: | poetry_install $(VENV_DIR)
 $(VENV_DIR):
 #	Update and add python support to create virtual environment

--- a/config_files/default.conf
+++ b/config_files/default.conf
@@ -25,7 +25,7 @@ server {
 
   #2nd test
   location /teste {
-    index /file_delete
+    index index.html
     autoindex on
     allowed_methods GET DELETE
     root root_html/file_delete
@@ -35,6 +35,12 @@ server {
 		root root_html/empty_page
     index index.html
   };
+
+  location /test_cgi {
+    root root_html/test_cgi
+    allowed_methods GET
+    cgi .py
+  }
 
   #3rd test
   location /123 {

--- a/config_files/default.conf
+++ b/config_files/default.conf
@@ -41,6 +41,7 @@ server {
     allowed_methods GET POST
     client_body_size 4096
     cgi .py
+    cgi_timeout 5
   }
 
   #3rd test

--- a/config_files/default.conf
+++ b/config_files/default.conf
@@ -38,7 +38,8 @@ server {
 
   location /test_cgi {
     root root_html/test_cgi
-    allowed_methods GET
+    allowed_methods GET POST
+    client_body_size 4096
     cgi .py
   }
 

--- a/config_files/ubuntu_tester.conf
+++ b/config_files/ubuntu_tester.conf
@@ -1,0 +1,31 @@
+server {
+  listen 127.0.0.1:3490
+  root root_html
+  server_name www.localhost localhost:3490
+  index index.html
+  cgi .bla /home/jchoi/Desktop/projects_42/webserv/ubuntu_cgi_tester
+
+  location / {
+    allowed_methods GET
+  }
+
+  location /put_test {
+    index /file_upload
+    root root_html/file_upload
+    allowed_methods PUT POST
+    client_body_size 104857601
+  };
+
+  location /post_body {
+    index index.html
+    client_body_size 100
+    allowed_methods POST
+    root root_html
+  };
+
+  location /directory {
+    root YoupiBanane
+    allowed_methods GET
+    index youpi.bad_extension
+  }
+};

--- a/root_html/test_cgi/cgi-bin/get_env.py
+++ b/root_html/test_cgi/cgi-bin/get_env.py
@@ -1,0 +1,3 @@
+import cgi
+
+cgi.test()

--- a/root_html/test_cgi/cgi-bin/inf_loop.py
+++ b/root_html/test_cgi/cgi-bin/inf_loop.py
@@ -1,0 +1,4 @@
+import time
+
+while True:
+    time.sleep(1)

--- a/root_html/test_cgi/cgi-bin/post_test.py
+++ b/root_html/test_cgi/cgi-bin/post_test.py
@@ -1,0 +1,29 @@
+import cgi
+import json
+import os
+import sys
+
+environ = os.environ
+headers = {
+        "Content-type": "text/html",
+    }
+
+for k, v in headers.items():
+    print(f"{k}: {v}")
+print()
+
+if environ["CONTENT_TYPE"] == "application/json":
+    print("Received json!<br>")
+    body = json.loads(''.join(sys.stdin.readlines()))
+    print(body)
+elif environ["CONTENT_TYPE"] == "application/x-www-form-urlencoded":
+    print("Received form!<br>")
+    body = ''.join(sys.stdin.readlines()).split("&")
+    for line in body:
+        pair = line.split("=", 1)
+        print(f"{pair[0]}: {pair[1]}", end="<br>")
+else:
+    for line in sys.stdin.readlines():
+        if line == "":
+            break
+        print(line.rstrip())

--- a/srcs/CgiHandler.cpp
+++ b/srcs/CgiHandler.cpp
@@ -1,6 +1,8 @@
 #include "CgiHandler.hpp"
 
-CgiHandler::CgiHandler() : _env(NULL), _argv(NULL) {}
+CgiHandler::CgiHandler() : _env(NULL), _argv(NULL), _timeout(0) {}
+
+CgiHandler::CgiHandler(size_t timeout) : _env(NULL), _argv(NULL), _timeout(timeout) {}
 
 CgiHandler::CgiHandler(CgiHandler const &cgi_handler) {
     this->_env_map = cgi_handler._env_map;
@@ -146,6 +148,8 @@ void CgiHandler::build(Server server, ServerLocation location, Request request, 
     this->_cgi = _get_cgi(server, location);
     this->_argv = _build_argv();
     this->_env = _build_env(server, request);
+    if (!this->_timeout)
+        this->_timeout = CGI_TIMEOUT;
 }
 
 std::string	CgiHandler::_get_cgi_output(std::FILE *tmp_out_file) {
@@ -205,7 +209,7 @@ int CgiHandler::_exec_cgi(int tmp_in_fd, int tmp_out_fd) {
 
         pid_t timer_pid = fork();
         if (timer_pid == 0) {
-            sleep(3); // TODO setup this as a per-server timeout
+            sleep(this->_timeout);
             _exit(0);
         }
 

--- a/srcs/CgiHandler.cpp
+++ b/srcs/CgiHandler.cpp
@@ -5,6 +5,7 @@ CgiHandler::CgiHandler() : _env(NULL), _argv(NULL) {}
 CgiHandler::CgiHandler(CgiHandler const &cgi_handler) {
     this->_env_map = cgi_handler._env_map;
     this->_filepath = cgi_handler._filepath;
+    this->_full_path = cgi_handler._full_path;
     this->_env = cgi_handler._env;
     this->_argv = cgi_handler._argv;
     this->_cgi = cgi_handler._cgi;
@@ -15,6 +16,7 @@ CgiHandler& CgiHandler::operator=(CgiHandler const &cgi_handler) {
     {
         this->_env_map = cgi_handler._env_map;
         this->_filepath = cgi_handler._filepath;
+        this->_full_path = cgi_handler._full_path;
         this->_env = cgi_handler._env;
         this->_argv = cgi_handler._argv;
         this->_cgi = cgi_handler._cgi;
@@ -49,20 +51,20 @@ std::string	CgiHandler::_get_default_cgi(std::string extension) {
         throw UnsupportedCGI(extension);
 }
 
-cgi_pair CgiHandler::_get_cgi() {
+cgi_pair CgiHandler::_get_cgi(Server &server, ServerLocation &location) {
     cgi_pair pair("", "");
 
-    if (_location.cgi_extension().size())
+    if (location.cgi_extension().size())
     {
-        pair.first = _location.cgi_extension();
-        if (_location.cgi_path().size())
-            pair.second = _location.cgi_path();
+        pair.first = location.cgi_extension();
+        if (location.cgi_path().size())
+            pair.second = location.cgi_path();
     }
     else
     {
-        pair.first = _server.cgi_extension();
-        if (_server.cgi_path().size())
-            pair.second = _server.cgi_path();
+        pair.first = server.cgi_extension();
+        if (server.cgi_path().size())
+            pair.second = server.cgi_path();
     }
     if (!pair.second.size())
         pair.second = _get_default_cgi(pair.first);
@@ -83,21 +85,20 @@ void CgiHandler::_add_header_to_env(Request &request) {
 }
 
 
-char** CgiHandler::_build_env(Request &request) {
+char** CgiHandler::_build_env(Server &server, Request &request) {
     char **_envp;
     _add_header_to_env(request);
     _env_map["AUTH_TYPE"] = "";
     _env_map["GATEWAY_INTERFACE"] = "CGI/1.1";
     _env_map["REQUEST_METHOD"] = request.method();
     _env_map["SCRIPT_NAME"] = _filepath;
-    _env_map["SERVER_NAME"] = _server.host();
-    _env_map["SERVER_PORT"] = Utils::itoa(_server.port());
+    _env_map["SERVER_NAME"] = server.host();
+    _env_map["SERVER_PORT"] = Utils::itoa(server.port());
     _env_map["SERVER_PROTOCOL"] = "HTTP/1.1";
     _env_map["SERVER_SOFTWARE"] = "webserv";
 
-    // TODO generate path info
-    _env_map["PATH_INFO"] = "";  // The extra path information, as given in the requested URL.
-    _env_map["PATH_TRANSLATED"] = "";  // The virtual-to-real mapped version of PATH_INFO.
+    _env_map["PATH_INFO"] = request.path();
+    _env_map["PATH_TRANSLATED"] = _full_path;
     // GET Specific
     if (request.method() == "GET" && request.query().size())
         _env_map["QUERY_STRING"] = request.query();
@@ -126,39 +127,39 @@ char** CgiHandler::_build_env(Request &request) {
 
 char** CgiHandler::_build_argv() {
     _argv = new char *[3];
+    std::string filename;
 
     _argv[0] = new char[_cgi.second.length() + 1];
     strcpy(_argv[0], _cgi.second.c_str());
 
-    _argv[1] = new char[_filepath.length() + 1];
-    strcpy(_argv[1], _filepath.c_str());
+    filename = this->_filepath.substr(this->_filepath.rfind("/") + 1);
+    _argv[1] = new char[filename.length() + 1];
+    strcpy(_argv[1], filename.c_str());
 
     _argv[2] = NULL;
     return _argv;
 }
 
-
-void CgiHandler::build(Server server, ServerLocation location, Request request, std::string filepath){
-    // TODO validate request method, if filepath exists
-    this->_server = server;
-    this->_location = location;
+void CgiHandler::build(Server server, ServerLocation location, Request request, std::string filepath, std::string full_path){
     this->_filepath = filepath;
-    this->_cgi = _get_cgi();
+    this->_full_path = full_path;
+    this->_cgi = _get_cgi(server, location);
     this->_argv = _build_argv();
-    this->_env = _build_env(request);
+    this->_env = _build_env(server, request);
 }
 
-std::string	CgiHandler::_get_cgi_output(std::FILE *tmp_file) {
+std::string	CgiHandler::_get_cgi_output(std::FILE *tmp_out_file) {
     int size;
     char *tmp;
     std::string buffer;
 
-    fseek(tmp_file, 0 , SEEK_END);
-    size = ftell(tmp_file);
-    rewind(tmp_file);
+    fseek(tmp_out_file, 0 , SEEK_END);
+    size = ftell(tmp_out_file);
+    rewind(tmp_out_file);
 
     tmp = new char[size + 1];
-    fread(tmp, sizeof(char), size, tmp_file);
+    memset(tmp, 0, size + 1);
+    fread(tmp, sizeof(char), size, tmp_out_file);
 
     buffer = std::string(tmp);
 
@@ -175,23 +176,83 @@ void CgiHandler::_send_cgi_response(int client_fd, std::string &buffer) {
     close(client_fd);
 }
 
-void CgiHandler::handle(int client_fd) {
-    int	pid, status;
-    std::string buffer;
-	std::FILE *tmp_file = std::tmpfile();
-	int tmp_fd = fileno(tmp_file);
+void CgiHandler::_chdir_wrapper(const char *path) {
+    int status = chdir(path);
+    if (status != 0)
+        throw ChdirError();
+}
 
-	pid = fork();
-	if (pid == 0)
-    {
-		dup2(tmp_fd, STDOUT_FILENO);
-        execve(this->_argv[0], this->_argv, this->_env);
-        close(tmp_fd);
+
+int CgiHandler::_exec_cgi(int tmp_in_fd, int tmp_out_fd) {
+    int status;
+    int std_io_fds[2];
+    std_io_fds[0] = dup(STDIN_FILENO);
+    std_io_fds[1] = dup(STDOUT_FILENO);
+    char buffer[4096];
+    memset(buffer, 0, 4096);
+
+    pid_t intermediate_pid = fork();
+    if (intermediate_pid == 0) {
+        pid_t cgi_pid = fork();
+        if (cgi_pid == 0) {
+            dup2(tmp_in_fd, STDIN_FILENO);
+            dup2(tmp_out_fd, STDOUT_FILENO);
+            close(tmp_in_fd);
+            close(tmp_out_fd);
+            execve(this->_argv[0], this->_argv, this->_env);
+            _exit(0);
+        }
+
+        pid_t timer_pid = fork();
+        if (timer_pid == 0) {
+            sleep(3); // TODO setup this as a per-server timeout
+            _exit(0);
+        }
+
+        pid_t exited_pid = wait(NULL);
+        if (exited_pid == cgi_pid)
+            kill(timer_pid, SIGKILL);
+        else
+            kill(cgi_pid, SIGKILL);
+
+        wait(&status);
+        if (WIFSIGNALED(status))
+            _exit(WIFSIGNALED(status));
+        _exit(0);
     }
-	waitpid(pid, &status, 0);
-    // TODO do we need to check status?
-    buffer = _get_cgi_output(tmp_file);
-    _send_cgi_response(client_fd, buffer);
-    fclose(tmp_file);
+    waitpid(intermediate_pid, &status, 0);
+    dup2(STDIN_FILENO, std_io_fds[0]);
+    dup2(STDOUT_FILENO, std_io_fds[1]);
+    close(std_io_fds[0]);
+    close(std_io_fds[1]);
+    return status;
+}
 
+
+void CgiHandler::handle(int client_fd, Request &request) {
+    int status;
+    std::string buffer, dir;
+    std::FILE *tmp_in_file = std::tmpfile();
+	std::FILE *tmp_out_file = std::tmpfile();
+	int tmp_in_fd = fileno(tmp_in_file);
+    int tmp_out_fd = fileno(tmp_out_file);
+    char *_pwd;
+
+    _pwd = getcwd(NULL, 0);
+    dir = this->_filepath.substr(0, this->_filepath.rfind("/"));
+    _chdir_wrapper(dir.c_str());
+
+    fputs(request.body().c_str(), tmp_in_file);
+    rewind(tmp_in_file);
+
+    status = _exec_cgi(tmp_in_fd, tmp_out_fd);
+
+    _chdir_wrapper(_pwd);
+    free(_pwd);
+    if (WIFEXITED(status))
+        throw CGIError();
+
+    buffer = _get_cgi_output(tmp_out_file);
+    _send_cgi_response(client_fd, buffer);
+    fclose(tmp_out_file);
 }

--- a/srcs/CgiHandler.cpp
+++ b/srcs/CgiHandler.cpp
@@ -99,8 +99,8 @@ char** CgiHandler::_build_env(Request &request) {
     _env_map["PATH_INFO"] = "";  // The extra path information, as given in the requested URL.
     _env_map["PATH_TRANSLATED"] = "";  // The virtual-to-real mapped version of PATH_INFO.
     // GET Specific
-    if (request.method() == "GET" && request.query() != "")
-        _env_map["QUERY_STRING"] = request.query(); // TODO fix request to receive query
+    if (request.method() == "GET" && request.query().size())
+        _env_map["QUERY_STRING"] = request.query();
     // POST Specific
     if (request.method() == "POST")
     {

--- a/srcs/CgiHandler.cpp
+++ b/srcs/CgiHandler.cpp
@@ -43,8 +43,6 @@ CgiHandler::~CgiHandler(void){
 }
 
 std::string	CgiHandler::_get_default_cgi(std::string extension) {
-    std::string temp;
-
     if (extension == ".py")
         return "/usr/bin/python3";
     else if (extension == ".php")
@@ -192,11 +190,9 @@ int CgiHandler::_exec_cgi(int tmp_in_fd, int tmp_out_fd) {
     int std_io_fds[2];
     std_io_fds[0] = dup(STDIN_FILENO);
     std_io_fds[1] = dup(STDOUT_FILENO);
-    char buffer[4096];
-    memset(buffer, 0, 4096);
 
-    pid_t intermediate_pid = fork();
-    if (intermediate_pid == 0) {
+    pid_t watcher_pid = fork();
+    if (watcher_pid == 0) {
         pid_t cgi_pid = fork();
         if (cgi_pid == 0) {
             dup2(tmp_in_fd, STDIN_FILENO);
@@ -224,7 +220,7 @@ int CgiHandler::_exec_cgi(int tmp_in_fd, int tmp_out_fd) {
             _exit(WIFSIGNALED(status));
         _exit(0);
     }
-    waitpid(intermediate_pid, &status, 0);
+    waitpid(watcher_pid, &status, 0);
     dup2(STDIN_FILENO, std_io_fds[0]);
     dup2(STDOUT_FILENO, std_io_fds[1]);
     close(std_io_fds[0]);

--- a/srcs/CgiHandler.cpp
+++ b/srcs/CgiHandler.cpp
@@ -1,0 +1,197 @@
+#include "CgiHandler.hpp"
+
+CgiHandler::CgiHandler() : _env(NULL), _argv(NULL) {}
+
+CgiHandler::CgiHandler(CgiHandler const &cgi_handler) {
+    this->_env_map = cgi_handler._env_map;
+    this->_filepath = cgi_handler._filepath;
+    this->_env = cgi_handler._env;
+    this->_argv = cgi_handler._argv;
+    this->_cgi = cgi_handler._cgi;
+}
+
+CgiHandler& CgiHandler::operator=(CgiHandler const &cgi_handler) {
+    if(this != &cgi_handler)
+    {
+        this->_env_map = cgi_handler._env_map;
+        this->_filepath = cgi_handler._filepath;
+        this->_env = cgi_handler._env;
+        this->_argv = cgi_handler._argv;
+        this->_cgi = cgi_handler._cgi;
+    }
+    return *this;
+}
+
+CgiHandler::~CgiHandler(void){
+    int i = 0;
+    if (this->_env)
+    {
+        while(this->_env[i])
+            delete[] this->_env[i++];
+        delete[] this->_env;
+    }
+    if (this->_argv)
+    {
+        for (int i = 0; i < 3; i++)
+            delete[] _argv[i];
+        delete[] _argv;
+    }
+}
+
+std::string	CgiHandler::_get_default_cgi(std::string extension) {
+    std::string temp;
+
+    if (extension == ".py")
+        return "/usr/bin/python3";
+    else if (extension == ".php")
+        return "/usr/bin/php-cgi";
+    else
+        throw UnsupportedCGI(extension);
+}
+
+cgi_pair CgiHandler::_get_cgi() {
+    cgi_pair pair("", "");
+
+    if (_location.cgi_extension().size())
+    {
+        pair.first = _location.cgi_extension();
+        if (_location.cgi_path().size())
+            pair.second = _location.cgi_path();
+    }
+    else
+    {
+        pair.first = _server.cgi_extension();
+        if (_server.cgi_path().size())
+            pair.second = _server.cgi_path();
+    }
+    if (!pair.second.size())
+        pair.second = _get_default_cgi(pair.first);
+
+    return pair;
+}
+
+void CgiHandler::_add_header_to_env(Request &request) {
+    std::string tmp_key;
+    env_map header = request.headers();
+    for(env_map::iterator it = header.begin(); it != header.end(); it++)
+	{
+        tmp_key = "http_" + it->first;
+        std::replace(tmp_key.begin(), tmp_key.end(), '-', '_');
+        std::transform(tmp_key.begin(), tmp_key.end(), tmp_key.begin(), toupper);
+        _env_map[tmp_key] = it->second;
+    }
+}
+
+
+char** CgiHandler::_build_env(Request &request) {
+    char **_envp;
+    _add_header_to_env(request);
+    _env_map["AUTH_TYPE"] = "";
+    _env_map["GATEWAY_INTERFACE"] = "CGI/1.1";
+    _env_map["REQUEST_METHOD"] = request.method();
+    _env_map["SCRIPT_NAME"] = _filepath;
+    _env_map["SERVER_NAME"] = _server.host();
+    _env_map["SERVER_PORT"] = Utils::itoa(_server.port());
+    _env_map["SERVER_PROTOCOL"] = "HTTP/1.1";
+    _env_map["SERVER_SOFTWARE"] = "webserv";
+
+    // TODO generate path info
+    _env_map["PATH_INFO"] = "";  // The extra path information, as given in the requested URL.
+    _env_map["PATH_TRANSLATED"] = "";  // The virtual-to-real mapped version of PATH_INFO.
+    // GET Specific
+    if (request.method() == "GET" && request.query() != "")
+        _env_map["QUERY_STRING"] = request.query(); // TODO fix request to receive query
+    // POST Specific
+    if (request.method() == "POST")
+    {
+        if (request.body().length())
+            _env_map["CONTENT_LENGTH"] = Utils::itoa(request.body().length());
+        if (_env_map.find("HTTP_CONTENT_TYPE") != _env_map.end())
+            _env_map["CONTENT_TYPE"] = _env_map["HTTP_CONTENT_TYPE"];
+    }
+
+    _envp = new char*[_env_map.size() + 1];
+    int i = 0;
+    std::string tmp;
+    for(env_map::iterator it = _env_map.begin(); it != _env_map.end(); it++)
+	{
+        tmp = it->first + "=" + it->second;
+        _envp[i] = new char[tmp.length() + 1];
+        strcpy(_envp[i], tmp.c_str());
+        i++;
+    }
+    _envp[_env_map.size()] = NULL;
+    return _envp;
+}
+
+char** CgiHandler::_build_argv() {
+    _argv = new char *[3];
+
+    _argv[0] = new char[_cgi.second.length() + 1];
+    strcpy(_argv[0], _cgi.second.c_str());
+
+    _argv[1] = new char[_filepath.length() + 1];
+    strcpy(_argv[1], _filepath.c_str());
+
+    _argv[2] = NULL;
+    return _argv;
+}
+
+
+void CgiHandler::build(Server server, ServerLocation location, Request request, std::string filepath){
+    // TODO validate request method, if filepath exists
+    this->_server = server;
+    this->_location = location;
+    this->_filepath = filepath;
+    this->_cgi = _get_cgi();
+    this->_argv = _build_argv();
+    this->_env = _build_env(request);
+}
+
+std::string	CgiHandler::_get_cgi_output(std::FILE *tmp_file) {
+    int size;
+    char *tmp;
+    std::string buffer;
+
+    fseek(tmp_file, 0 , SEEK_END);
+    size = ftell(tmp_file);
+    rewind(tmp_file);
+
+    tmp = new char[size + 1];
+    fread(tmp, sizeof(char), size, tmp_file);
+
+    buffer = std::string(tmp);
+
+    delete [] tmp;
+    return buffer;
+}
+
+void CgiHandler::_send_cgi_response(int client_fd, std::string &buffer) {
+    std::string status_line, response;
+
+    status_line = "HTTP/1.1 200 OK\r\n";
+    response = status_line + buffer;
+    send(client_fd, response.c_str(), response.length(), 0);
+    close(client_fd);
+}
+
+void CgiHandler::handle(int client_fd) {
+    int	pid, status;
+    std::string buffer;
+	std::FILE *tmp_file = std::tmpfile();
+	int tmp_fd = fileno(tmp_file);
+
+	pid = fork();
+	if (pid == 0)
+    {
+		dup2(tmp_fd, STDOUT_FILENO);
+        execve(this->_argv[0], this->_argv, this->_env);
+        close(tmp_fd);
+    }
+	waitpid(pid, &status, 0);
+    // TODO do we need to check status?
+    buffer = _get_cgi_output(tmp_file);
+    _send_cgi_response(client_fd, buffer);
+    fclose(tmp_file);
+
+}

--- a/srcs/CgiHandler.hpp
+++ b/srcs/CgiHandler.hpp
@@ -16,17 +16,20 @@
 #include "Response.hpp"
 #include "Utils.hpp"
 
+#define CGI_TIMEOUT 15;
+
 typedef std::pair<std::string, std::string> cgi_pair;
 typedef std::map<std::string, std::string> env_map;
 
 class CgiHandler {
 	private:
-		env_map			_env_map;
+		env_map		_env_map;
 		std::string	_filepath;
 		std::string _full_path;
 		char**		_env;
 		char**		_argv;
 		cgi_pair	_cgi;
+		size_t		_timeout;
 
 		cgi_pair	_get_cgi(Server &server, ServerLocation &location);
 		std::string	_get_default_cgi(std::string extension);
@@ -40,6 +43,7 @@ class CgiHandler {
 
 	public:
 		CgiHandler(void);
+		CgiHandler(size_t timeout);
 		CgiHandler(CgiHandler const&cgi_handler);
 		CgiHandler& operator=(CgiHandler const&cgi_handler);
 		~CgiHandler(void);

--- a/srcs/CgiHandler.hpp
+++ b/srcs/CgiHandler.hpp
@@ -1,0 +1,68 @@
+#ifndef CGIHANDLER_HPP
+#define CGIHANDLER_HPP
+
+#include <iostream>
+#include <map>
+#include <cstdio>
+#include <algorithm>
+#include <string>
+#include <cstring>
+#include <sys/wait.h>
+#include <sys/socket.h>
+#include "Server.hpp"
+#include "ServerLocation.hpp"
+#include "Request.hpp"
+#include "Response.hpp"
+#include "Utils.hpp"
+
+typedef std::pair<std::string, std::string> cgi_pair;
+typedef std::map<std::string, std::string> env_map;
+
+class CgiHandler {
+	private:
+		Server			_server;
+		ServerLocation	_location;
+		env_map			_env_map;
+		std::string	_filepath;
+		char**		_env;
+		char**		_argv;
+		cgi_pair	_cgi;
+
+		cgi_pair	_get_cgi();
+		std::string	_get_default_cgi(std::string extension);
+		std::string	_get_cgi_output(std::FILE *tmp_file);
+		void		_send_cgi_response(int client_fd, std::string &buffer);
+		void		_add_header_to_env(Request &request);
+		char**		_build_env(Request &request);
+		char**		_build_argv();
+
+	public:
+		CgiHandler(void);
+		CgiHandler(CgiHandler const&cgi_handler);
+		CgiHandler& operator=(CgiHandler const&cgi_handler);
+		~CgiHandler(void);
+
+		void build(Server server, ServerLocation location, Request request, std::string filepath);
+		void handle(int client_fd);
+
+		class MallocError : public std::exception
+		{
+			public:
+				const char* what() const throw(){ return "Malloc error"; };
+		};
+
+		class UnsupportedCGI : public std::exception
+		{
+			private:
+				std::string _extension;
+			public:
+				UnsupportedCGI(std::string extension) : _extension(extension) {};
+				~UnsupportedCGI(void) throw () {};
+
+				const char* what() const throw() {
+					return ("Unsupported CGI extension: " + _extension).c_str(); 
+				};
+		};
+};
+
+#endif

--- a/srcs/CgiHandler.hpp
+++ b/srcs/CgiHandler.hpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <string>
 #include <cstring>
+#include <unistd.h>
 #include <sys/wait.h>
 #include <sys/socket.h>
 #include "Server.hpp"
@@ -20,21 +21,22 @@ typedef std::map<std::string, std::string> env_map;
 
 class CgiHandler {
 	private:
-		Server			_server;
-		ServerLocation	_location;
 		env_map			_env_map;
 		std::string	_filepath;
+		std::string _full_path;
 		char**		_env;
 		char**		_argv;
 		cgi_pair	_cgi;
 
-		cgi_pair	_get_cgi();
+		cgi_pair	_get_cgi(Server &server, ServerLocation &location);
 		std::string	_get_default_cgi(std::string extension);
-		std::string	_get_cgi_output(std::FILE *tmp_file);
+		std::string	_get_cgi_output(std::FILE *tmp_out_file);
 		void		_send_cgi_response(int client_fd, std::string &buffer);
 		void		_add_header_to_env(Request &request);
-		char**		_build_env(Request &request);
+		char**		_build_env(Server &server, Request &request);
 		char**		_build_argv();
+		void		_chdir_wrapper(const char *path);
+		int			_exec_cgi(int tmp_in_fd, int tmp_out_fd);
 
 	public:
 		CgiHandler(void);
@@ -42,13 +44,25 @@ class CgiHandler {
 		CgiHandler& operator=(CgiHandler const&cgi_handler);
 		~CgiHandler(void);
 
-		void build(Server server, ServerLocation location, Request request, std::string filepath);
-		void handle(int client_fd);
+		void build(Server server, ServerLocation location, Request request, std::string filepath, std::string full_path);
+		void handle(int client_fd, Request &request);
 
-		class MallocError : public std::exception
+		class ChdirError : public std::exception
 		{
 			public:
-				const char* what() const throw(){ return "Malloc error"; };
+				const char* what() const throw(){ return "Chdir error"; };
+		};
+
+		class CGIError : public std::exception
+		{
+			public:
+				const char* what() const throw(){ return "CGI error"; };
+		};
+
+		class InternalServerError : public std::exception
+		{
+			public:
+				const char* what() const throw(){ return "Internal Server error"; };
 		};
 
 		class UnsupportedCGI : public std::exception

--- a/srcs/Http.cpp
+++ b/srcs/Http.cpp
@@ -72,7 +72,7 @@ void Http::handle() {
 	_set_location();
 	if (_validate_request())
 		return;
-	CgiHandler cgi_handler;
+	CgiHandler cgi_handler(this->_cgi_timeout());
 	try {
 		if (_check_cgi(cgi_handler)) {
 			cgi_handler.handle(_client_fd, _request);
@@ -260,6 +260,13 @@ std::string Http::_cgi_path(void) const {
 		return _http_server.cgi_path();
 }
 
+
+size_t Http::_cgi_timeout(void) const {
+	if (_has_location)
+		return _http_location.cgi_timeout();
+	else
+		return _http_server.cgi_timeout();
+}
 
 std::string Http::_index(void) const {
 	if (_has_location)

--- a/srcs/Http.cpp
+++ b/srcs/Http.cpp
@@ -185,12 +185,15 @@ void Http::_response_handler() {
 
 void Http::_get_handler(std::string response_file_path) {
 	std::string prevStatusCode = "500";
-	std::string prevPath = "";
+	std::string prevPath = response_file_path;
 
-
-	if (Utils::file_exists(response_file_path)) {
+	if (isDirectory(response_file_path) && !_autoindex()) {
 		prevStatusCode = "200";
-		prevPath = response_file_path;
+		prevPath = prevPath + "/" + _index();
+	}
+
+	if (Utils::file_exists(prevPath)) {
+		prevStatusCode = "200";
 	}
 	else {
 		prevStatusCode = "404";

--- a/srcs/Http.hpp
+++ b/srcs/Http.hpp
@@ -26,7 +26,7 @@ class Http {
 
 		void _set_http_server();
 		void _set_location();
-		bool _check_cgi();
+		bool _check_cgi(CgiHandler &cgi_handler);
 		bool _has_cgi_extension(std::string filename, std::string cgi_extension);
 		void _response_handler();
 		void _get_handler(std::string response_file_path);

--- a/srcs/Http.hpp
+++ b/srcs/Http.hpp
@@ -32,16 +32,17 @@ class Http {
 		void _get_handler(std::string response_file_path);
 		bool _validate_request();
 		std::string _get_file_error(std::string status_code);
-
+ 
 		std::string								_root(void) const;
-		std::string				_index(void) const;
-		std::string 							_cgi_extension(void) const;
-		std::string 							_cgi_path(void) const;
+		std::string								_index(void) const;
+		std::string								_cgi_extension(void) const;
+		std::string								_cgi_path(void) const;
+		size_t									_cgi_timeout(void) const;
 		std::map<int, std::string>				_erros_pages(void) const;
 		int										_body_size_limit(void) const;
 		bool									_autoindex(void) const;
 		std::vector<std::string>				_http_methods(void) const;
-		std::pair<std::string, std::string> _http_redirect(void) const;
+		std::pair<std::string, std::string>		_http_redirect(void) const;
 
 		void _response_handle_safe(std::string statuscode, std::string pathHTML, bool autoindex, std::string data);
 

--- a/srcs/Http.hpp
+++ b/srcs/Http.hpp
@@ -9,6 +9,7 @@
 #include <Response.hpp>
 #include <Server.hpp>
 #include <ServerLocation.hpp>
+#include <CgiHandler.hpp>
 
 class Http {
 	private:
@@ -25,6 +26,8 @@ class Http {
 
 		void _set_http_server();
 		void _set_location();
+		bool _check_cgi();
+		bool _has_cgi_extension(std::string filename, std::string cgi_extension);
 		void _response_handler();
 		void _get_handler(std::string response_file_path);
 		bool _validate_request();
@@ -32,6 +35,8 @@ class Http {
 
 		std::string								_root(void) const;
 		std::string				_index(void) const;
+		std::string 							_cgi_extension(void) const;
+		std::string 							_cgi_path(void) const;
 		std::map<int, std::string>				_erros_pages(void) const;
 		int										_body_size_limit(void) const;
 		bool									_autoindex(void) const;

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -12,6 +12,7 @@ Request::Request(Request const &request) {
 	_method = request.method();
 	_path = request.path();
 	_query = request.query();
+	_query_map = request.query_map();
 	_protocol = request.protocol();
 	_protocol_version = request.protocol_version();
 	_buffer = new char[BUFFER_SIZE];
@@ -27,6 +28,7 @@ Request &Request::operator=(Request const &request) {
 	_method = request.method();
 	_path = request.path();
 	_query = request.query();
+	_query_map = request.query_map();
 	_protocol = request.protocol();
 	_protocol_version = request.protocol_version();
 	_buffer = new char[BUFFER_SIZE];
@@ -127,19 +129,20 @@ void	Request::_get_full_body(std::size_t size) {
 }
 
 void	Request::_parse_first_line() {
-	std::vector<std::string> tokens;
-	std::string							 line;
+	std::vector<std::string> tokens, path_tokens;
+	std::string line;
+	size_t question_pos;
 
 	line = _get_line();
 	if (line.length() > MAX_URI_LENGTH)
 		throw URITooLongError();
 	tokens = Utils::string_split(line, "\t ");
 	_set_method(tokens[0]);
-	// addLog(logFile,"Request first line> Method:" + tokens[0]);
-	_set_path(tokens[1]);
-	// addLog(logFile,"Request first line> Path:" + tokens[1]);
+	question_pos = tokens[1].find("?");
+	if (question_pos != std::string::npos)
+		_set_query(tokens[1].substr(question_pos + 1));
+	_set_path(tokens[1].substr(0, question_pos));
 	_set_protocol_info(tokens[2]);
-	// addLog(logFile,"Request first line> Protocol:" + tokens[2]);
 }
 
 void	Request::_parse_headers() {
@@ -215,7 +218,20 @@ void	Request::_set_headers(std::string line) {
 void	Request::_set_body(std::string line) { (void)line; }
 void	Request::_set_method(std::string line) { _method = line; }
 void	Request::_set_path(std::string line) { _path = line; }
-void	Request::_set_query(std::string line) { (void)line; }
+void	Request::_set_query(std::string line) {
+		std::vector<std::string> query_params, query_pair;
+		std::vector<std::string>::iterator it;
+
+		query_params = Utils::string_split(line, "&");
+		for (it = query_params.begin(); it != query_params.end(); it++)
+		{
+			query_pair = Utils::string_split(*it, "=");
+			if (query_pair.size() != 2)
+				throw BadRequestError();
+			_query_map[query_pair[0]] = query_pair[1];
+		}
+		_query = line;
+	}
 void	Request::_set_protocol_info(std::string line) {
 	std::vector<std::string> protocol_infos = Utils::string_split(line, "/");
 
@@ -238,6 +254,7 @@ std::string							Request::body(void) const { return _body; }
 std::string							Request::method(void) const { return _method; }
 std::string							Request::path(void) const { return _path; }
 std::string							Request::query(void) const { return _query; }
+std::map<std::string, std::string>	Request::query_map(void) const { return _query_map; }
 std::string							Request::protocol(void) const { return _protocol; }
 std::string							Request::protocol_version(void) const { return _protocol_version; }
 

--- a/srcs/Request.hpp
+++ b/srcs/Request.hpp
@@ -20,6 +20,7 @@ class Request {
 		std::string							_method;
 		std::string							_path;
 		std::string							_query;
+		std::map<std::string, std::string>	_query_map;
 		std::string							_protocol;
 		std::string							_protocol_version;
 		char								*_buffer;
@@ -61,6 +62,7 @@ class Request {
 		std::string							method(void) const;
 		std::string							path(void) const;
 		std::string							query(void) const;
+		std::map<std::string, std::string>	query_map(void) const;
 		std::string							protocol(void) const;
 		std::string							protocol_version(void) const;
 

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -283,8 +283,6 @@ void Response::ReadHTML(std::string code_pag, std::string msgStatusCode, std::st
 
 		while (getline(file, line))
 		{
-			//std::cout << "line" << std::endl;
-			//std::cout << line << " - " << line.length() <<std::endl;
 			buffer=line.c_str();
 			buffer_len=line.length();
 			_send_safe(_client_fd, buffer, buffer_len, MSG_NOSIGNAL);

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1,7 +1,8 @@
 #include <Server.hpp>
 
 
-Server::Server(void) : _autoindex(false) {}
+// TODO server/location needs a default body_size_limit to protect against uninitialized. 
+Server::Server(void) : _autoindex(false), _cgi_timeout(0) {}
 
 Server::Server(Server const &server) {
 	_server_names = server.server_names();

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1,8 +1,7 @@
 #include <Server.hpp>
 
 
-// TODO server/location needs a default body_size_limit to protect against uninitialized. 
-Server::Server(void) : _autoindex(false), _cgi_timeout(0) {}
+Server::Server(void) : _body_size_limit(0), _autoindex(false), _cgi_timeout(0) {}
 
 Server::Server(Server const &server) {
 	_server_names = server.server_names();

--- a/srcs/Server.hpp
+++ b/srcs/Server.hpp
@@ -30,6 +30,7 @@ class Server {
 		std::vector<std::string>				_index;
 		std::map<std::string, ServerLocation>	_locations;
 		std::string								_cgi_extension;
+		std::string								_cgi_path;
 
 		void	_parse_location_attributes(std::ifstream &fs, std::string line, std::string path);
 		void	_set_server_attributes(std::vector<std::string> line_tokens);
@@ -69,6 +70,7 @@ class Server {
 		std::vector<std::string>				index(void) const;
 		std::map<std::string, ServerLocation>	locations(void) const;
 		std::string								cgi_extension(void) const;
+		std::string								cgi_path(void) const;
 		ServerLocation							location(std::string path) const;
 
 	class InvalidServerParam : public std::exception
@@ -81,6 +83,12 @@ class Server {
 	{
 		public:
 			const char* what() const throw(){ return "Missing Server Args"; };
+	};
+
+	class InvalidNumberOfConfigArgs : public std::exception
+	{
+		public:
+			const char* what() const throw(){ return "Invalid Number of Config Args"; };
 	};
 
 	class InvalidHost : public std::exception
@@ -105,6 +113,12 @@ class Server {
 	{
 		public:
 			const char* what() const throw(){ return "Invalid CGI Extension"; };
+	};
+
+	class InvalidCGIPath: public std::exception
+	{
+		public:
+			const char* what() const throw(){ return "Invalid CGI Path"; };
 	};
 
 	class InvalidAutoIndexParam: public std::exception

--- a/srcs/Server.hpp
+++ b/srcs/Server.hpp
@@ -23,7 +23,7 @@ class Server {
 		int										_port;
 		std::map<int, std::string>				_erros_pages;
 		std::vector<std::string>				_http_methods;
-		std::pair<std::string, std::string>				_http_redirect;
+		std::pair<std::string, std::string>		_http_redirect;
 		std::string								_root;
 		int										_body_size_limit;
 		bool									_autoindex;
@@ -31,6 +31,7 @@ class Server {
 		std::map<std::string, ServerLocation>	_locations;
 		std::string								_cgi_extension;
 		std::string								_cgi_path;
+		size_t									_cgi_timeout;
 
 		void	_parse_location_attributes(std::ifstream &fs, std::string line, std::string path);
 		void	_set_server_attributes(std::vector<std::string> line_tokens);
@@ -39,6 +40,7 @@ class Server {
 		void	_set_error_page_attribute(std::vector<std::string> line_tokens);
 		void	_set_client_body_size_attribute(std::vector<std::string> line_tokens);
 		void	_set_cgi_attribute(std::vector<std::string> line_tokens);
+		void	_set_cgi_timeout(std::vector<std::string> line_tokens);
 		void	_set_http_methods_attribute(std::vector<std::string> line_tokens);
 		void	_set_http_redirect_attribute(std::vector<std::string> line_tokens);
 		void	_set_root_attribute(std::vector<std::string> line_tokens);
@@ -71,6 +73,7 @@ class Server {
 		std::map<std::string, ServerLocation>	locations(void) const;
 		std::string								cgi_extension(void) const;
 		std::string								cgi_path(void) const;
+		size_t									cgi_timeout(void) const;
 		ServerLocation							location(std::string path) const;
 
 	class InvalidServerParam : public std::exception
@@ -119,6 +122,12 @@ class Server {
 	{
 		public:
 			const char* what() const throw(){ return "Invalid CGI Path"; };
+	};
+
+	class InvalidCGITimeout: public std::exception
+	{
+		public:
+			const char* what() const throw(){ return "Invalid CGI Timeout"; };
 	};
 
 	class InvalidAutoIndexParam: public std::exception

--- a/srcs/ServerLocation.cpp
+++ b/srcs/ServerLocation.cpp
@@ -124,6 +124,7 @@ void	ServerLocation::_set_cgi_attribute(std::vector<std::string> line_tokens) {
 		throw InvalidCGIExtension();
 	}
 	this->_cgi_extension = line_tokens[1];
+	this->_cgi_path = "";
 	switch (line_tokens.size()) {
 	case 2:
 		break;

--- a/srcs/ServerLocation.cpp
+++ b/srcs/ServerLocation.cpp
@@ -11,6 +11,7 @@ ServerLocation::ServerLocation(Server const &server_location) {
 	_index = server_location.index();
 	_cgi_extension = server_location.cgi_extension();
 	_cgi_path = server_location.cgi_path();
+	_cgi_timeout = server_location.cgi_timeout();
 	_erros_pages = server_location.erros_pages();
 	_body_size_limit = server_location.body_size_limit();
 }
@@ -23,6 +24,7 @@ ServerLocation::ServerLocation(ServerLocation const &server_location) {
 	_index = server_location.index();
 	_cgi_extension = server_location.cgi_extension();
 	_cgi_path = server_location.cgi_path();
+	_cgi_timeout = server_location.cgi_timeout();
 	_erros_pages = server_location.erros_pages();
 	_body_size_limit = server_location.body_size_limit();
 }
@@ -36,6 +38,7 @@ ServerLocation &ServerLocation::operator=(ServerLocation const &server_location)
 		_index = server_location.index();
 		_cgi_extension = server_location.cgi_extension();
 		_cgi_path = server_location.cgi_path();
+		_cgi_timeout = server_location.cgi_timeout();
 		_erros_pages = server_location.erros_pages();
 		_body_size_limit = server_location.body_size_limit();
 	}
@@ -68,6 +71,7 @@ bool ServerLocation::autoindex(void) const { return _autoindex; }
 std::vector<std::string> ServerLocation::index(void) const { return _index; }
 std::string ServerLocation::cgi_extension(void) const { return _cgi_extension; }
 std::string ServerLocation::cgi_path(void) const { return _cgi_path; }
+size_t ServerLocation::cgi_timeout(void) const { return _cgi_timeout; }
 
 void	ServerLocation::_set_location_attributes(std::vector<std::string> line_tokens) {
 	if (line_tokens.size() <= 1) {
@@ -83,6 +87,8 @@ void	ServerLocation::_set_location_attributes(std::vector<std::string> line_toke
 		_set_client_body_size_attribute(line_tokens);
 	else if (line_tokens[0] == "cgi")
 		_set_cgi_attribute(line_tokens);
+	else if (line_tokens[0] == "cgi_timeout")
+		_set_cgi_timeout(line_tokens);
 	else if (line_tokens[0] == "allowed_methods")
 		_set_http_methods_attribute(line_tokens);
 	else if (line_tokens[0] == "autoindex")
@@ -151,6 +157,27 @@ void	ServerLocation::_set_cgi_attribute(std::vector<std::string> line_tokens) {
 	}
 }
 
+void	ServerLocation::_set_cgi_timeout(std::vector<std::string> line_tokens) {
+	int time;
+
+	if (line_tokens.size() != 2) {
+		std::cerr << "Cgi Timeout - Too many arguments." << std::endl;
+		throw InvalidCGITimeout();
+	}
+
+	if (!Utils::is_number(line_tokens[1])) {
+		std::cerr << "Cgi Timeout - " << line_tokens[1] << " is not a valid positive integer." << std::endl;
+		throw InvalidCGITimeout();
+	}
+
+	time = std::atoi(line_tokens[1].c_str());
+	if (time <= 0) {
+		std::cerr << "Cgi Timeout - " << line_tokens[1] << " is not a valid positive integer." << std::endl;
+		throw InvalidCGITimeout();
+	}
+	this->_cgi_timeout = time;
+}
+
 void	ServerLocation::_set_http_methods_attribute(std::vector<std::string> line_tokens) {
 	// do not need validation - allow any http method name and then only verify it is included
   this->_http_methods.clear();
@@ -201,6 +228,8 @@ std::ostream &operator<<(std::ostream &out, ServerLocation const &server_locatio
 	out << "  Cgi extension: " << server_location.cgi_extension() << std::endl;
 
 	out << "Cgi path: " << server_location.cgi_path() << std::endl;
+
+	out << "Cgi timeout: " << server_location.cgi_timeout() << std::endl;
 
 	out << "  Root: " << server_location.root() << std::endl;
 

--- a/srcs/ServerLocation.cpp
+++ b/srcs/ServerLocation.cpp
@@ -1,7 +1,7 @@
 #include <ServerLocation.hpp>
 
 
-ServerLocation::ServerLocation(void) : _autoindex(false), _cgi_timeout(0) {}
+ServerLocation::ServerLocation(void) : _autoindex(false), _cgi_timeout(0), _body_size_limit(0) {}
 
 ServerLocation::ServerLocation(Server const &server_location) {
 	_http_methods = server_location.http_methods();

--- a/srcs/ServerLocation.cpp
+++ b/srcs/ServerLocation.cpp
@@ -1,7 +1,7 @@
 #include <ServerLocation.hpp>
 
 
-ServerLocation::ServerLocation(void) : _autoindex(false) {}
+ServerLocation::ServerLocation(void) : _autoindex(false), _cgi_timeout(0) {}
 
 ServerLocation::ServerLocation(Server const &server_location) {
 	_http_methods = server_location.http_methods();

--- a/srcs/ServerLocation.hpp
+++ b/srcs/ServerLocation.hpp
@@ -19,6 +19,7 @@ class ServerLocation {
 		bool												_autoindex;
 		std::vector<std::string>		_index;
 		std::string									_cgi_extension;
+		std::string									_cgi_path;
 		std::map<int, std::string>	_erros_pages;
 		int													_body_size_limit;
 
@@ -50,6 +51,7 @@ class ServerLocation {
 		bool																	autoindex(void) const;
 		std::vector<std::string>							index(void) const;
 		std::string														cgi_extension(void) const;
+		std::string														cgi_path(void) const;
 
 	class InvalidLocationParam : public std::exception
 	{
@@ -61,6 +63,12 @@ class ServerLocation {
 	{
 		public:
 			const char* what() const throw(){ return "Missing Location Args"; };
+	};
+
+	class InvalidNumberOfConfigArgs : public std::exception
+	{
+		public:
+			const char* what() const throw(){ return "Invalid Number of Config Args"; };
 	};
 
 	class InvalidRoot: public std::exception
@@ -79,6 +87,12 @@ class ServerLocation {
 	{
 		public:
 			const char* what() const throw(){ return "Invalid CGI Extension"; };
+	};
+
+	class InvalidCGIPath: public std::exception
+	{
+		public:
+			const char* what() const throw(){ return "Invalid CGI Path"; };
 	};
 
 	class InvalidAutoIndexParam: public std::exception

--- a/srcs/ServerLocation.hpp
+++ b/srcs/ServerLocation.hpp
@@ -13,20 +13,22 @@ class Server;
 
 class ServerLocation {
 	private:
-		std::vector<std::string>		_http_methods;
+		std::vector<std::string>			_http_methods;
 		std::pair<std::string, std::string>	_http_redirect;
-		std::string									_root;
-		bool												_autoindex;
-		std::vector<std::string>		_index;
-		std::string									_cgi_extension;
-		std::string									_cgi_path;
-		std::map<int, std::string>	_erros_pages;
-		int													_body_size_limit;
+		std::string							_root;
+		bool								_autoindex;
+		std::vector<std::string>			_index;
+		std::string							_cgi_extension;
+		std::string							_cgi_path;
+		size_t								_cgi_timeout;
+		std::map<int, std::string>			_erros_pages;
+		int									_body_size_limit;
 
 		void	_set_location_attributes(std::vector<std::string>);
 		void	_set_error_page_attribute(std::vector<std::string> line_tokens);
 		void	_set_client_body_size_attribute(std::vector<std::string> line_tokens);
 		void	_set_cgi_attribute(std::vector<std::string> line_tokens);
+		void	_set_cgi_timeout(std::vector<std::string> line_tokens);
 		void	_set_http_methods_attribute(std::vector<std::string> line_tokens);
 		void	_set_http_redirect_attribute(std::vector<std::string> line_tokens);
 		void	_set_root_attribute(std::vector<std::string> line_tokens);
@@ -43,15 +45,16 @@ class ServerLocation {
 
 		void parse_location_attributes(std::ifstream &fs, std::string line);
 
-		std::map<int, std::string>						erros_pages(void) const;
-		std::vector<std::string>							http_methods(void) const;
-		std::pair<std::string, std::string>						http_redirect(void) const;
-		std::string														root(void) const;
-		int																		body_size_limit(void) const;
-		bool																	autoindex(void) const;
-		std::vector<std::string>							index(void) const;
-		std::string														cgi_extension(void) const;
-		std::string														cgi_path(void) const;
+		std::map<int, std::string>			erros_pages(void) const;
+		std::vector<std::string>			http_methods(void) const;
+		std::pair<std::string, std::string>	http_redirect(void) const;
+		std::string							root(void) const;
+		int									body_size_limit(void) const;
+		bool								autoindex(void) const;
+		std::vector<std::string>			index(void) const;
+		std::string							cgi_extension(void) const;
+		std::string							cgi_path(void) const;
+		size_t								cgi_timeout(void) const;
 
 	class InvalidLocationParam : public std::exception
 	{
@@ -93,6 +96,12 @@ class ServerLocation {
 	{
 		public:
 			const char* what() const throw(){ return "Invalid CGI Path"; };
+	};
+
+	class InvalidCGITimeout: public std::exception
+	{
+		public:
+			const char* what() const throw(){ return "Invalid CGI Timeout"; };
 	};
 
 	class InvalidAutoIndexParam: public std::exception

--- a/srcs/Utils.cpp
+++ b/srcs/Utils.cpp
@@ -171,4 +171,9 @@ namespace Utils {
 		signal(SIGQUIT, handle_signal);
 	}
 
+	string itoa(int n) {
+		stringstream ss;
+  		ss << n;
+		return ss.str();
+	}
 }

--- a/srcs/Utils.hpp
+++ b/srcs/Utils.hpp
@@ -2,6 +2,7 @@
 #define UTILS_HPP
 
 #include <iostream>
+#include <sstream>
 #include <vector>
 #include <csignal>
 #include <stdlib.h>
@@ -44,6 +45,7 @@ namespace Utils {
 	bool file_exists(const std::string filename);
 	void handle_signal(int signal);
 	void listen_signals(void);
+	std::string itoa(int n);
 }
 
 

--- a/srcs/WebServ.cpp
+++ b/srcs/WebServ.cpp
@@ -33,9 +33,6 @@ void WebServ::event_loop(void) {
 		addLog(logFile,"Start Polling");
 
 		while (true) {
-			/*Looping fica ativo por 15 segundos, para criarmos um timeout*/
-			//if (std::difftime(std::time(0), TS) > 15)
-			//	break;
 			connections = poll((pollfd *)&(*_pollfds.begin()), _pollfds.size(), -1);
 			if (connections == -1)
 				throw PoolError();

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -35,10 +35,10 @@ int	main(int argc, char **argv) {
 		addLog(logFile,"Init HTML");
 		addLog(logFile,"Initialize Server");
 		web_serv.init(argc, argv);
-		//std::cout << web_serv << std::endl;
 		addLog(logFile,"Initialize Server Event Loop");
 		web_serv.event_loop();
 	} catch (const std::exception& e) {
+		// TODO add log
 		std::cout << e.what() << std::endl;
 		return(1);
 	}

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -38,7 +38,7 @@ int	main(int argc, char **argv) {
 		addLog(logFile,"Initialize Server Event Loop");
 		web_serv.event_loop();
 	} catch (const std::exception& e) {
-		// TODO add log
+		addLog(logFile, e.what());
 		std::cout << e.what() << std::endl;
 		return(1);
 	}


### PR DESCRIPTION
### Adds support for CGI in the configuration of either a server or a location:

- `cgi <cgi_extension>`
where the web server will check later if this extension is supported.
Example: `cgi .py`

- `cgi <cgi_extension> <cgi_executable>`
where the web server will check if the executable exists.
Example: `cgi .py /usr/bin/python3`
This can be useful in cases of python virtual environments, for example.

By default, if no executable is given, we have the following executables assumed:
- `.py` -> `/usr/bin/python3`
- `.php` -> `/usr/bin/php-cgi`

### Adds support for a CGI timeout in the configuration of either a server or a location:
- `cgi_timeout <time_in_seconds>` Default: 15s (Configurable at `CgiHandler.hpp`)

### Fixes dir URI handling with autoindex off:
- Now, when a URI is mapped to a dir, and the location's autoindex is off, it searches for `<dir>/<index>`, assuming the server/location has an index.
---

The cgi script is expected to return http headers and body.
The web server only returns the status line in the case of a CGI script.

Once a location is found in the webserver that has support to the CGI, the script is expected to be located at:
<server/location root>/cgi-bin/<script>.

Request example:
`GET http://localhost:8000/my_cgi_location/cgi-bin/script.py/extra_path_to_cgi&param_to_cgi=123`
This will look for a location called `my_cgi_location` in the server, and execute `script.py`, passing the extra path and query parameters to the CGI as environment variables.